### PR TITLE
add tomcat user's $HOME management if not already done

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,4 +34,12 @@ class zookeeper::install {
     creates => '/tmp/exhibitor.3'
   }
 
+  ensure_resource('file', '/home/tomcat', {
+    'ensure' => 'directory',
+    'owner'  => 'tomcat',
+    'group'  => 'tomcat',
+    'mode'   => '0700',
+    'before' => Package['netflix-exhibitor-tomcat']
+  })
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,12 +8,12 @@
   "project_page": "https://github.com/Talend/puppet-zookeeper",
   "issues_url": "https://github.com/Talend/puppet-zookeeper/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=1.0.0 <5.0.0"},
-    {"name":"puppet/archive","version_requirement":"0.x"},
-    {"name":"nanliu/staging","version_requirement":"1.x"},
-    {"name":"puppetlabs/java","version_requirement":"1.x"},
-    {"name":"puppetlabs/tomcat","version_requirement":"1.x"},
-    {"name":"maestrodev/wget","version_requirement":"1.x"},
-    {"name":"computology/packagecloud","version_requirement":"0.x"}
+    {"name":"puppetlabs/stdlib", "version_requirement":">=1.0.0 <5.0.0"},
+    {"name":"puppet/archive", "version_requirement":"0.x"},
+    {"name":"nanliu/staging", "version_requirement":"1.x"},
+    {"name":"puppetlabs/java", "version_requirement":"1.x"},
+    {"name":"puppetlabs/tomcat", "version_requirement":"1.x"},
+    {"name":"maestrodev/wget", "version_requirement":"1.x"},
+    {"name":"computology/packagecloud", "version_requirement":"0.x"}
   ]
 }

--- a/spec/acceptance/zookeeper_spec.rb
+++ b/spec/acceptance/zookeeper_spec.rb
@@ -7,6 +7,11 @@ describe 'zookeeper' do
       subject { command('/usr/bin/java -cp /opt/apache-tomcat/lib/catalina.jar org.apache.catalina.util.ServerInfo') }
       its(:stdout) { should include 'Apache Tomcat/8.5.2' }
     end
+    describe 'Tomcat Home Directory' do
+       subject { file('/home/tomcat') }
+       it { should be_directory }
+       it { should be_owned_by 'tomcat' }
+    end
   end
 
   context 'When Exhibitor configured' do


### PR DESCRIPTION
puppetlabs-tomcat does not create $HOME for tomcat but it is needed for using /home/tomcat/.java/.userPrefs/.user.lock.tomcat
test added, tested with "bundle exec kitchen test"